### PR TITLE
Remove sorting prior to comparing items

### DIFF
--- a/addon/utilities.js
+++ b/addon/utilities.js
@@ -49,8 +49,6 @@ export const hasManyChanged = function(one, other, polymorphic) {
   }
 
   if (polymorphic) {
-    one = Ember.A(one).sortBy('id');
-    other = Ember.A(other).sortBy('id');
     for (let i = 0, len = one.length; i < len; i++) {
       if (serializedModelChanged(one[i], other[i])) {
         return true;
@@ -59,8 +57,6 @@ export const hasManyChanged = function(one, other, polymorphic) {
     return false;
   }
 
-  one.sort();
-  other.sort();
   for (let i = 0, len = one.length; i < len; i++) {
     if (one[i] !== other[i]) {
       return true;

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -298,7 +298,7 @@ test('#changed ( replacing )', function(assert) {
     ['pets', [cat, dog], [], true, 'removing all from a polymorphichasMany is a change'],
     ['pets', [cat, dog], [cat], true, 'removing one from a polymorphic hasMany is a change'],
     ['pets', [cat], [cat, dog], true, 'adding to a polymorphic hasMany is a change'],
-    ['pets', [dog, cat], [cat, dog], false, 'order of polymorphic hasMany change is not a change'],
+    ['pets', [dog, cat], [cat, dog], true, 'change to the order of polymorphic hasMany is a change'],
   ];
 
   for (let test of tests) {
@@ -665,7 +665,7 @@ test('#isDirty resets on update (with non auto save model)', function(assert) {
       assert.equal(project.get('hasDirtyAttributes'), false);
       assert.equal(project.get('hasDirtyRelations'), false);
       mockTeardown();
-      done(); 
+      done();
     });
   });
 });


### PR DESCRIPTION
Going forward “hasMany” will be marked as dirty when the order of the items changes.

You can find the discussion on the reasoning here https://github.com/danielspaniel/ember-data-change-tracker/issues/14