### PR TITLE
Renamed `changed` in `model-ext` to `modelChanges`

### DIFF
--- a/addon/model-ext.js
+++ b/addon/model-ext.js
@@ -25,7 +25,7 @@ Model.reopen({
    *
    * @returns {*}
    */
-  changed() {
+  modelChanges() {
     let changed = Object.assign({}, this.changedAttributes());
     let trackerInfo = Tracker.metaInfo(this);
     for (let key in trackerInfo) {

--- a/addon/tracker.js
+++ b/addon/tracker.js
@@ -446,12 +446,12 @@ export default class Tracker {
     });
 
     const hasDirtyRelations = function() {
-      const changed = model.changed();
+      const changed = model.modelChanges();
       return !!relations.find(key => changed[key]);
     };
 
     const hasDirtyAttributes = function() {
-      const changed = model.changed();
+      const changed = model.modelChanges();
       return !!attrs.find(key => changed[key]);
     };
 

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -246,10 +246,10 @@ test('#save method resets changed if auto tracking', function(assert) {
     mockUpdate(user);
 
     user.save().then(() => {
-      assert.ok(!user.changed().info, 'clears changed info after save');
-      assert.ok(!user.changed().company, 'clears changed company after save');
-      assert.ok(!user.changed().projects, 'clears changed projects after save');
-      assert.ok(!user.changed().pets, 'clears changed pets after save');
+      assert.ok(!user.modelChanges().info, 'clears changed info after save');
+      assert.ok(!user.modelChanges().company, 'clears changed company after save');
+      assert.ok(!user.modelChanges().projects, 'clears changed projects after save');
+      assert.ok(!user.modelChanges().pets, 'clears changed pets after save');
       mockTeardown();
       done();
     });
@@ -263,7 +263,7 @@ test('#changed ( modifying ) attribute of type undefined', function(assert) {
 
   blob.foo = 2;
 
-  let changed = company.changed().blob;
+  let changed = company.modelChanges().blob;
   assert.ok(changed);
 });
 
@@ -273,7 +273,7 @@ test('#changed ( modifying ) attribute of type that does not serialize to string
 
   blob.foo = 2;
 
-  let changed = user.changed().blob;
+  let changed = user.modelChanges().blob;
   assert.ok(changed);
 });
 
@@ -282,7 +282,7 @@ test('#changed ( modifying ) attribute of type "object"', function(assert) {
   let user = make('user', { info });
   info.dude = 3;
 
-  let changed = (user.changed().info);
+  let changed = (user.modelChanges().info);
   assert.ok(changed);
 });
 
@@ -318,7 +318,7 @@ test('#changed ( replacing )', function(assert) {
     let user = make('user', { [key]: firstValue });
 
     setModel(user, key, nextValue);
-    assert.equal(!!user.changed()[key], expected, message);
+    assert.equal(!!user.modelChanges()[key], expected, message);
   }
 });
 


### PR DESCRIPTION
Hi Daniel,

I encountered a naming problem in a project I'm working on. If there is a `DS.attr` called `changed`, the `changed` method is overridden with a computed property and the tracker methods will fail. A possible solution is to change the model's attribute to `changedAt` or similar, but this has also to be done server-side (like in my case).

So a more unique name like `modelChanges` (changes done to the model) should prevent this collision.

What do you think about this approach? It's a huge API break, but should be more future proof.