### PR TITLE
BUGFIX: Assertion on transform / createRecord

### DIFF
--- a/addon/tracker.js
+++ b/addon/tracker.js
@@ -85,7 +85,7 @@ export default class Tracker {
    */
   static transformFn(model, attributeType) {
     let transformType = attributeType || 'object';
-    return model.store.serializerFor(model.constructor.modelName).transformFor(transformType);
+    return model.store.serializerFor(model._internalModel.modelName).transformFor(transformType);
   }
 
   /**

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -738,3 +738,11 @@ test('#isDirty resets on update (with non auto save model)', function(assert) {
     });
   });
 });
+
+test('Fails because of assertion error when run in isolation', function(assert) {
+  assert.expect(1);
+
+  Ember.run(() => FactoryGuy.store.createRecord('user'));
+  assert.ok(true);
+});
+


### PR DESCRIPTION
Supersedes https://github.com/danielspaniel/ember-data-change-tracker/pull/31 and closes https://github.com/danielspaniel/ember-data-change-tracker/issues/30 (?)


My only issue with this test case (to my knowledge any test case) verifying that this behavior was broken is that (in my test runs) the assertion error for some reason doesn't fail the test, unless you run it in isolation. The error will be logged in the console regardless

I also don't know what the root cause is, so the test case name isn't very descriptive, but feel free to clean up.

you'll have to checkout https://github.com/danielspaniel/ember-data-change-tracker/pull/34/commits/c033fca5a6bd73444be06ac6cbe0cbac5e333253 and run the test case in isolation to see the failure

For convenience:
```sh
git remote add alexander-avlarez git@github.com:alexander-alvarez/ember-data-change-tracker.git
git fetch alexander-alvarez
git checkout c033fca5a6bd73444be06ac6cbe0cbac5e333253

```