### PR TITLE
Pass arguments to reload method

### DIFF
--- a/addon/model-ext.js
+++ b/addon/model-ext.js
@@ -121,7 +121,7 @@ Model.reopen({
 
   // There is no didReload callback on models, so have to override reload
   reload() {
-    let promise = this._super();
+    let promise = this._super(...arguments);
     promise.then(() => {
       if (Tracker.isAutoSaveEnabled(this)) {
         this.saveChanges();


### PR DESCRIPTION
Ember Data 3.2 added support for `options` argument in `DS.Model.reload()`.

Implementation PR: https://github.com/emberjs/data/pull/5414
API docs link: https://emberjs.com/api/ember-data/3.2/classes/DS.Model/methods/reload?anchor=reload

When this addon is installed all models do not accept `options` as an argument to `reload()` method.