### PR TITLE
Add guard to prevent evaluation of 'known' for linked relationships when key not being tracked

### DIFF
--- a/addon/model-ext.js
+++ b/addon/model-ext.js
@@ -142,7 +142,7 @@ Model.reopen({
   },
 
   observeUnknownRelationshipLoaded(sender, key/*, value, rev*/) {
-    if (Tracker.trackingIsSetup(this)) {
+    if (Tracker.trackingIsSetup(this) && Tracker.isTracking(this, key)) {
       let saved = Tracker.saveLoadedRelationship(this, key);
       if (saved) {
         this.removeObserver(key, this, 'observeUnknownRelationshipLoaded');

--- a/addon/tracker.js
+++ b/addon/tracker.js
@@ -127,6 +127,18 @@ export default class Tracker {
   }
 
   /**
+   * Find whether this key is currently being tracked.
+   *
+   * @param {DS.Model} model
+   * @param {string} [key]
+   * @returns {boolean} true if this key is being tracked. false otherwise
+   */
+  static isTracking(model, key) {
+    let info = (model.constructor.trackerKeys || {});
+    return !!info[key];
+  }
+
+  /**
    * On the model you can set options like:
    *
    *   changeTracker: {auto: true}


### PR DESCRIPTION
In response to #70 I've added a simple guard to prevent checking 'known' for relationships not being tracked.

I've found it very hard to prove this in test however, as I am unfamiliar with the FactoryGuy mocking framework nor do I have access to any code that is demonstrating the bug described.

It would be good for @BnitoBzh or @pjcarly could verify this satisfies their needs. 