### PR TITLE
Quicker init

### DIFF
--- a/addon/tracker.js
+++ b/addon/tracker.js
@@ -426,7 +426,7 @@ export default class Tracker {
   static saveChanges(model, {except = []} = {}) {
     let metaInfo = this.metaInfo(model);
     let keys = Object.keys(metaInfo).filter(key => !except.includes(key));
-    keys.forEach(key => Tracker.saveKey(model, key));
+    Tracker.saveKeys(model, keys);
   }
 
   /**
@@ -459,6 +459,29 @@ export default class Tracker {
     model.notifyPropertyChange('hasDirtyRelations');
   }
 
+    /**
+   * Save the value from an array of keys model's tracker hash
+   * and save the relationship states if keys represents a relationship
+   *
+   * @param {DS.Model} model
+   * @param {Array} keys to save
+   */
+
+  static saveKeys(model, keys){
+    let modelTracker = model.get(ModelTrackerKey) || {},
+    relationshipsKnownTracker = model.get(RelationshipsKnownTrackerKey) || {},
+    isNew   = model.get('isNew');
+
+    keys.forEach(key => {
+      modelTracker[key] = isNew ? undefined : this.serialize(model, key);
+      relationshipsKnownTracker[key] = isNew ? true : this.isKnown(model, key);
+    })
+    model.beginPropertyChanges();
+    model.set(ModelTrackerKey, modelTracker);
+    model.set(RelationshipsKnownTrackerKey, relationshipsKnownTracker);
+    model.endPropertyChanges();
+  }
+
   /**
    * Save current model key value in model's tracker hash
    * and save the relationship state if key represents a relationship
@@ -467,14 +490,7 @@ export default class Tracker {
    * @param {String} key attribute/association name
    */
   static saveKey(model, key) {
-    let modelTracker = model.get(ModelTrackerKey) || {},
-        relationshipsKnownTracker = model.get(RelationshipsKnownTrackerKey) || {},
-        isNew   = model.get('isNew');
-    modelTracker[key] = isNew ? undefined : this.serialize(model, key);
-    model.set(ModelTrackerKey, modelTracker);
-
-    relationshipsKnownTracker[key] = isNew ? true : this.isKnown(model, key);
-    model.set(RelationshipsKnownTrackerKey, relationshipsKnownTracker);
+    this.saveKeys(model, [key]);
   }
 
   /**

--- a/addon/tracker.js
+++ b/addon/tracker.js
@@ -476,10 +476,7 @@ export default class Tracker {
       modelTracker[key] = isNew ? undefined : this.serialize(model, key);
       relationshipsKnownTracker[key] = isNew ? true : this.isKnown(model, key);
     })
-    model.beginPropertyChanges();
-    model.set(ModelTrackerKey, modelTracker);
-    model.set(RelationshipsKnownTrackerKey, relationshipsKnownTracker);
-    model.endPropertyChanges();
+    model.setProperties({[ModelTrackerKey]:modelTracker, [RelationshipsKnownTrackerKey]: relationshipsKnownTracker})
   }
 
   /**

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -9,7 +9,7 @@ import { initializer as modelInitializer } from 'ember-data-change-tracker';
 import Tracker, { ModelTrackerKey, RelationshipsKnownTrackerKey } from 'ember-data-change-tracker/tracker';
 import sinon from 'sinon';
 import EmberObject, { get, observer } from '@ember/object';
-
+import { settled } from '@ember/test-helpers'
 modelInitializer();
 
 const setModel = (model, attr, value) => {
@@ -30,11 +30,12 @@ module('Unit | Model', function(hooks) {
     manualSetup(this);
   });
 
-  test('only sets up tracking meta data once on model type', function(assert) {
+  test('only sets up tracking meta data once on model type', async function(assert) {
     sinon.stub(Tracker, 'options').returns({auto: true});
     let getTrackerInfo = sinon.stub(Tracker, 'getTrackerInfo').returns({autoSave: true});
 
     let dog = make('dog');
+    await settled();
     assert.ok(dog.constructor.alreadySetupTrackingMeta, 'auto save set up metaData');
 
     Tracker.setupTracking(dog); // try and setup again


### PR DESCRIPTION
Some recent-ish changes to Ember revolving around observer management ended up slowing down the initialization of models significantly.

This seems to improve performance quite a bit by cutting down on the number of times an individual model gets / sets during setup.