### PR TITLE
Fix incorrect this._super on event methods

### DIFF
--- a/addon/model-ext.js
+++ b/addon/model-ext.js
@@ -88,22 +88,18 @@ Model.reopen({
   initTracking(){
 
       this.didCreate = () => {
-        this._super(...arguments);
         this.saveOnCreate();
       }
 
       this.didUpdate  = () => {
-        this._super(...arguments);
         this.saveOnUpdate();
       }
 
       this.didDelete = () => {
-        this._super(...arguments);
         this.clearSavedAttributes();
       }
 
       this.ready = () => {
-        this._super(...arguments);
         this.setupTrackerMetaData();
         this.setupUnknownRelationshipLoadObservers();
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data-change-tracker",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Track changes and rollback object attributes and relationships. Ember data 2.5+",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
As noted in #65 (Replace deprecated usage of Ember.Evented) the deprecation warnings continue to appear, due to the this._super calls inside the event definitions.

This pull request simply removes the this._super calls (thus removing the deprecation warnings).

As far as I can tell, the super calls are not needed anyway - walking through the code:
- Ember Data calls 'trigger'
- trigger calls the 'ready' event in ember-data-change-tracker code
- this code calls this._super -- which evaluates to 'trigger' again!
- but back in the original trigger call (after the event is done), it already calls _super on itself!

So it appears that the this._super in the event is not actually going to gain anything?

Can we bring in this pull request until the future-work is done to move away from the ready call/etc?