### PR TITLE
fix: access belongs-to current state

### DIFF
--- a/addon/utilities.js
+++ b/addon/utilities.js
@@ -11,7 +11,7 @@ export const relationShipTransform = {
   belongsTo: {
     serialize(model, key, options) {
       let relationship = model.belongsTo(key).belongsToRelationship;
-      let value = relationship.hasOwnProperty('inverseRecordData') ? relationship.inverseRecordData: relationship.canonicalState;
+      let value = relationship.hasOwnProperty('inverseRecordData') ? relationship.inverseRecordData: relationship.localState;
       return value && modelTransform(value, options.polymorphic);
     },
 


### PR DESCRIPTION
ember-data@3.28.3 no longer has a canonicalState in relationships of type belongsTo. It seems to have moved to localState.
https://github.com/emberjs/data/blob/v3.28.3/packages/record-data/addon/-private/relationships/state/belongs-to.ts#L21