### PR TITLE
fix: fallback to localState when canonicalState is not present

### DIFF
--- a/addon/utilities.js
+++ b/addon/utilities.js
@@ -11,7 +11,10 @@ export const relationShipTransform = {
   belongsTo: {
     serialize(model, key, options) {
       let relationship = model.belongsTo(key).belongsToRelationship;
-      let value = relationship.hasOwnProperty('inverseRecordData') ? relationship.inverseRecordData: relationship.canonicalState;
+      const state = relationship.canonicalState || relationship.localState;
+      let value = relationship.hasOwnProperty("inverseRecordData")
+        ? relationship.inverseRecordData
+        : state;
       return value && modelTransform(value, options.polymorphic);
     },
 


### PR DESCRIPTION
We were using Ember 3.15 in one of our projects and `ember-data-change-tracker` was working perfectly. When we upgraded our application to Ember 3.28(LTS) version, the addon stopped tracking the changes on `belongsTo` relationships.

At first, I was guessing the problem could be related to the addon's Ember version. When I upgraded the addon's Ember version to 3.28, it didn't solve the problem.

Then I dig deeper and saw that it was happening because of not having `canonicalState` attribute on `belongsTo` relationships. Instead, we have `localState` and `remoteState` attributes.

In order to make the fix backward compatible, I kept `canonicalState` as the first option and if we don't have it, we fall back to `localState`. 

Here are the debugger outputs to explain the situation even better:

<img width="793" alt="Screen Shot 2022-07-30 at 22 32 26" src="https://user-images.githubusercontent.com/1655222/181976156-9283e767-f28f-40e6-b84d-e4dca3bbe529.png">
<img width="1061" alt="Screen Shot 2022-07-30 at 22 33 04" src="https://user-images.githubusercontent.com/1655222/181976264-37c05020-6d8a-47e8-8279-13eb57345291.png">

With this PR, we are making this addon compatible with Ember 3.28 and probably newer versions of Ember. 

@danielspaniel Let me know if you see any problems with the PR. I would be happy to address the problems and help further. 